### PR TITLE
prioritize emotes based on case

### DIFF
--- a/src/containers/Channel.tsx
+++ b/src/containers/Channel.tsx
@@ -824,6 +824,19 @@ class Channel extends React.Component<Props, State> {
       emoteCompletions = _.filter(emotes, (emote) => {
         return emote.code.toLowerCase().startsWith(sanitizedWord)
       }).map((emote) => emote.code)
+
+      // order emotes matching the case first, then typical ordering
+      emoteCompletions.sort((a: string, b: string) => {
+        if (a.startsWith(word)) {
+          if (b.startsWith(word)) {
+            return a.localeCompare(b)
+          }
+          return -1
+        } else if (b.startsWith(word)) {
+          return 1
+        }
+        return a.localeCompare(b)
+      })
     }
 
     if (prioritizeUsernames) {


### PR DESCRIPTION
**Describe the pull request**

Added a sort for emotes to prioritize case when auto completing. (addresses #6)

I didn't add a setting, as I'm not sure it's noticable enough to need one. But I'll definitely leave that up to your decision. I also only implemented on the emote side, and not the username side. I didn't think it made as much sense there.

**Why**

Lots of detail from @BlueberryKing on #6, but mostly so you don't have to type `kapp` for `Kappa`.

**How**

A relatively simple sort after the emotes are filtered before they're autocompleted for the user.

**Screenshots**

Before:
![before](https://user-images.githubusercontent.com/1820386/45055640-64d69900-b05e-11e8-98fc-da9d4e59a523.png)

After:
![after](https://user-images.githubusercontent.com/1820386/45055644-686a2000-b05e-11e8-8520-19ab730ed2b0.png)
