### PR TITLE
User name auto complete on certain commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### 🚀 New Feature
+
+- When autocompleting a username argument of a command, only usernames will now be suggested ([#32](https://github.com/HiDeoo/YaTA/pull/32) - [nD00rn](https://github.com/nD00rn)).
+
 # 1.11.0
 
 ### 🚀 New Feature

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
   "bugs": {
     "url": "https://github.com/HiDeoo/YaTA/issues"
   },
-  "contributors": [],
+  "contributors": [
+    "nDoorn <ndoorn@outlook.com>"
+  ],
   "homepage": "https://yata.now.sh"
 }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -352,7 +352,7 @@ export default class Input extends React.Component<Props, State> {
 
           this.completions = this.props.getCompletions(
             word,
-            previousCharacter === '@',
+            previousCharacter === '@' || Command.isUserNameAutoCompletable(text),
             start === 1 && Command.isCommand(previousCharacter)
           )
         }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -352,7 +352,7 @@ export default class Input extends React.Component<Props, State> {
 
           this.completions = this.props.getCompletions(
             word,
-            previousCharacter === '@' || Command.isUserNameAutoCompletable(text),
+            previousCharacter === '@' || Command.isUsernameCompletableCommandArgument(text, cursor),
             start === 1 && Command.isCommand(previousCharacter)
           )
         }

--- a/src/constants/command.ts
+++ b/src/constants/command.ts
@@ -161,7 +161,7 @@ export type CommandDescriptor = {
 /**
  * A command argument.
  */
-type CommandArgument = {
+export type CommandArgument = {
   name: string
   optional?: boolean
 }

--- a/src/libs/Command.ts
+++ b/src/libs/Command.ts
@@ -45,6 +45,31 @@ export default class Command {
   }
 
   /**
+   * Checks if the message can currently be autocomplete with a user name
+   * @param message - A message which potentially could be autocompleted with
+   * a user name
+   */
+  public static isUserNameAutoCompletable(message: string) {
+    return _.map(Commands, (description, name) => {
+      return {
+        name,
+        requiresUserName: _.some(description.arguments, (arg) => arg.name === 'username'),
+      }
+    })
+      .filter((cmd) => {
+        return cmd.requiresUserName === true
+      })
+      .some((cmd) => {
+        const isFirstArgument: boolean = message.split(' ').length === 2
+
+        const regex: string = `^[\\/|.]${cmd.name}(?:$|\\s)`
+        const matches: boolean = RegExp(regex, 'i').test(message)
+
+        return isFirstArgument && matches
+      })
+  }
+
+  /**
    * Parses a message as a whisper command (/w user message).
    * @return The whisper details.
    */

--- a/src/libs/Command.ts
+++ b/src/libs/Command.ts
@@ -45,7 +45,7 @@ export default class Command {
   }
 
   /**
-   * Checks if the message can currently be autocomplete with a user name
+   * Checks if the given message should be auto completed with a user name
    * @param message - A message which potentially could be autocompleted with
    * a user name
    */


### PR DESCRIPTION
**Describe the pull request**

Certain commands in the Twitch chat require a user name to be entered
after the command. This PR enforces the auto completion to only
suggest user names and not to suggest any of the available emotes for
the user when providing the first argument.

This feature will work for the following commands at this moment of
writing.

/ban
/block
/mod
/purge
/timeout
/unban
/unblock
/unmod
/untimeout
/unvip
/user
/vip
/w

**Why**

This prevents the user from entering an emote instead a username when 
for example trying to ban someone.

**How**

Whenever the 'tab' key is pressed it checks if the one of the previous mentioned commands is typed in, next it checks if the word the user currently is typing is the first argument after the command. If this first argument check was not in place the user would not be able to auto complete any available emote.

The commands which are processed like this are described in the Commands.ts found in the constants folder. In the command description it states if a username is an argument or not.