### PR TITLE
Remove custom user-agent when using Robotty

### DIFF
--- a/src/libs/Robotty.ts
+++ b/src/libs/Robotty.ts
@@ -49,7 +49,6 @@ export default class Robotty {
   private static fetch(url: string) {
     const headers = new Headers({
       Accept: 'application/json',
-      'User-Agent': 'YaTA',
     })
 
     const request = new Request(url, { headers })


### PR DESCRIPTION
This is no longer required and also fixes at the same time an issue with Firefox which was erroring on a CORS preflight request with a custom user-agent.