### PR TITLE
Update fetchRelationship to new Helix endpoint

### DIFF
--- a/src/libs/Twitch.ts
+++ b/src/libs/Twitch.ts
@@ -653,14 +653,14 @@ export default class Twitch {
     }
 
     const params = {
-      from_id: Twitch.userId,
-      to_id: targetId,
+      user_id: Twitch.userId,
+      broadcaster_id: targetId,
     }
 
-    const response = await Twitch.fetch(TwitchApi.Helix, '/users/follows', params)
+    const response = await Twitch.fetch(TwitchApi.Helix, '/channels/followed', params)
     const relationships = (await response.json()) as RawRelationships
 
-    if (relationships.total === 1) {
+    if (relationships.data.length === 1) {
       const relationship = _.head(relationships.data)
 
       if (!_.isNil(relationship)) {


### PR DESCRIPTION

**Describe the pull request**

/users/follows/ is no more, /channels/followed can be used to get the relationship information. According to https://dev.twitch.tv/docs/api/reference/#get-followed-channels the response with both user_id and broadcaster_id is "...contains this broadcaster if the user follows them. If not specified, the response contains all broadcasters that the user follows" so the data array will be either one entry or ALL entries. The total count will always be the total number of followed channels.

**Why**

Channel Details is broken
![image](https://github.com/HiDeoo/YaTA/assets/148640/1a6913a8-b359-4572-8a9c-b8e9db5359d0)

![image](https://github.com/HiDeoo/YaTA/assets/148640/26ceffa1-abf5-45b9-be28-795ab617dd4a)


**How**

Updated to new API

