### PR TITLE
Update fetchFollowersCount to new Helix endpoint

### DIFF
--- a/src/libs/Twitch.ts
+++ b/src/libs/Twitch.ts
@@ -677,7 +677,7 @@ export default class Twitch {
    * @return The total number of followers.
    */
   public static async fetchFollowersCount(targetId: string) {
-    const response = await Twitch.fetch(TwitchApi.Helix, '/users/follows', { to_id: targetId })
+    const response = await Twitch.fetch(TwitchApi.Helix, '/channels/followers', { broadcaster_id: targetId })
     const relationships = (await response.json()) as RawRelationships
 
     return relationships.total


### PR DESCRIPTION
**Describe the pull request**

/users/follows/ is no more, and /channels/followers can be used to get a channel's follower count.

**Why**

Current API is broken
![image](https://github.com/HiDeoo/YaTA/assets/148640/26ceffa1-abf5-45b9-be28-795ab617dd4a)

**How**

Updated to new API
