### PR TITLE
Normalize error string checking for resetUser

### DIFF
--- a/src/containers/ErrorBoundary.tsx
+++ b/src/containers/ErrorBoundary.tsx
@@ -51,11 +51,12 @@ class ErrorBoundary extends React.Component<Props, State> {
    */
   public componentDidCatch(error: Error) {
     const { message } = error
+    const messageNormalized = message.toLowerCase()
 
     if (
-      message.includes('invalid oauth token') ||
-      message.includes('Missing token for authenticated request') ||
-      message.includes('Login authentication failed')
+      messageNormalized.includes('invalid oauth token') ||
+      messageNormalized.includes('missing token for authenticated request') ||
+      messageNormalized.includes('login authentication failed')
     ) {
       this.props.resetUser()
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots if necessary.

Make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).
-->

**Why**

Looks like at some point Twitch the error message to "Invalid OAuth token" so the generic error warning comes up and the only way around seems to be reset storage.

**How**

Lowercased string before checking for "reset user" terms.
